### PR TITLE
Make `esgf local` and `esgf missing` consistent

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,2 +1,3 @@
 exclude_paths:
     - docs/_build/**/*
+    - test/**/*

--- a/arccssive2/cli.py
+++ b/arccssive2/cli.py
@@ -266,28 +266,17 @@ def local(user, debug, latest,
     if len(version) > 0:
         filters.append(ExtendedMetadata.version.ilike(any_(['%d'%x for x in version])))
 
-    # Main query
-    q = (s.query(Path.path.label('path'), ExtendedMetadata.version)
-            .join(Path.dataset)
-            .join(Path.extended)
-            .join(Path.checksum)
-            .distinct(Checksum.sha256)
-            .order_by(Checksum.sha256, ExtendedMetadata.version)
-            .filter(*filters))
-
-    if latest:
-        # Match against the latest versions from ESGF
-        esgf_q = find_checksum_id(query=None,
-            latest=latest,
+    q = find_local_path(s, query=None,
+            distrib=True,
+            #replica=replica,
+            latest=None,
+            #cf_standard_name=cf_standard_name,
+            #experiment_family=experiment_family,
+            #product=product,
+            #variable_long_name=variable_long_name,
+            #source_id=source_id,
             **terms
             )
 
-        q = q.join(esgf_q, 
-            or_(Checksum.md5 == esgf_q.c.checksum, 
-                Checksum.sha256 == esgf_q.c.checksum))
-
-    sub = q.subquery()
-    q = s.query(sub).order_by(sub.c.version.desc().nullslast(), sub.c.path)
-
     for result in q:
-        print(result.path)
+        print(result[0])

--- a/arccssive2/cli.py
+++ b/arccssive2/cli.py
@@ -174,7 +174,7 @@ def missing(query, user, debug, distrib, replica, latest,
     q = find_missing_id(s, ' '.join(query),
             distrib=distrib,
             replica=replica,
-            latest=latest,
+            latest=None,
             cf_standard_name=cf_standard_name,
             experiment_family=experiment_family,
             product=product,
@@ -184,7 +184,7 @@ def missing(query, user, debug, distrib, replica, latest,
             )
     
     for result in q:
-        print(result.id)
+        print(result[0])
 
 @esgf.command()
 @click.option('--user', help='Username for database')

--- a/arccssive2/esgf.py
+++ b/arccssive2/esgf.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import requests
 from sqlalchemy.sql import column, label
 from sqlalchemy.orm import aliased
-from sqlalchemy import String, Float, or_
+from sqlalchemy import String, Float, Integer, or_
 from .pgvalues import values
 from .model import Path, Checksum, metadata_dataset_link
 
@@ -110,7 +110,7 @@ def find_checksum_id(query, **kwargs):
     Returns a sqlalchemy selectable containing the ESGF id and checksum for
     each query match
     """
-    response = esgf_query(query, 'checksum,id', **kwargs)
+    response = esgf_query(query, 'checksum,id,title,version', **kwargs)
 
     if response['response']['numFound'] == 0:
         raise Exception('No matches found on ESGF, check at %s'%link_to_esgf(query, **kwargs))
@@ -121,9 +121,16 @@ def find_checksum_id(query, **kwargs):
     table = values([
             column('checksum', String),
             column('id', String),
+            column('title', String),
+            column('verision', Integer),
             column('score', Float),
         ],
-        *[(doc['checksum'][0], doc['id'], doc['score']) 
+        *[(
+            doc['checksum'][0],
+            doc['id'],
+            doc['title'],
+            doc['version'],
+            doc['score']) 
             for doc in response['response']['docs']],
         alias_name = 'esgf'
         )

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -17,8 +17,15 @@ from __future__ import print_function
 
 from arccssive2.cli import *
 import pytest
+from arccssive2.db import connect
 
 from click.testing import CliRunner
+from test_esgf import updated_query
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 
 @pytest.fixture(scope='module')
 def runner():
@@ -27,3 +34,25 @@ def runner():
 def test_local(runner):
     result = runner.invoke(local, ['--help'])
     assert result.exit_code == 0
+
+def dummy_connect(*args, **kwargs):
+    return None
+
+@pytest.mark.parametrize('command', [local, missing])
+def test_versions(command, runner, session):
+    """
+    Check the --latest/--all-versions flags are passed correctly to esgf_query
+    """
+    with mock.patch('arccssive2.cli.connect', side_effect=dummy_connect):
+        with mock.patch('arccssive2.cli.Session', side_effect = lambda: session):
+            with mock.patch('arccssive2.esgf.esgf_query', side_effect=updated_query) as query:
+
+                # Check the query args are passed correctly
+                result = runner.invoke(command)
+                assert query.call_args[1]['latest'] == None
+
+                result = runner.invoke(command, ['--all-versions'])
+                assert query.call_args[1]['latest'] == None
+
+                result = runner.invoke(command, ['--latest'])
+                assert query.call_args[1]['latest'] == True

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -49,10 +49,16 @@ def test_versions(command, runner, session):
 
                 # Check the query args are passed correctly
                 result = runner.invoke(command)
+                print(result.output)
+                assert query.called
                 assert query.call_args[1]['latest'] == None
 
                 result = runner.invoke(command, ['--all-versions'])
+                print(result.output)
+                assert query.called
                 assert query.call_args[1]['latest'] == None
 
                 result = runner.invoke(command, ['--latest'])
-                assert query.call_args[1]['latest'] == True
+                print(result.output)
+                assert query.called
+                assert query.call_args[1]['latest'] == 'true'

--- a/test/test_esgf.py
+++ b/test/test_esgf.py
@@ -46,6 +46,8 @@ def missing_query(*args, **kwags):
                 'docs': [{
                     'id': 'abcde',
                     'checksum': ['1234'],
+                    'title': 'foo',
+                    'version': '1',
                     'score': 1.0,
                     }],
                 }

--- a/test/test_esgf.py
+++ b/test/test_esgf.py
@@ -67,6 +67,7 @@ def present_query(*args, **kwags):
                     'checksum': ['3ea60eacd2a6e98b13fc3b242f585fdc'],
                     'title': 'va_6hrPlev_FGOALS-g2_historical_r3i1p1_1999010106-2000010100.nc',
                     'version': '1',
+                    'latest': 'true',
                     'score': 1.0,
                     }],
                 }
@@ -86,6 +87,7 @@ def updated_query(*args, **kwags):
                     'checksum': ['1234'],
                     'version': '2',
                     'title': 'va_6hrPlev_FGOALS-g2_historical_r3i1p1_1999010106-2000010100.nc',
+                    'latest': 'true',
                     'score': 1.0,
                     }],
                 }
@@ -158,3 +160,21 @@ def test_find_local_path_updated(session):
     with mock.patch('arccssive2.esgf.esgf_query', side_effect=updated_query):
         results = find_local_path(session, '')
         assert results.count() == 1
+
+def test_find_missing_id_updated_latest(session):
+    """
+    File has been updated, but is still present
+    latest=true should prefer ESGF replies when they have the latest flag
+    """
+    with mock.patch('arccssive2.esgf.esgf_query', side_effect=updated_query):
+        results = find_missing_id(session, '', latest=True)
+        assert results.count() == 1
+
+def test_find_local_path_updated_latest(session):
+    """
+    File has been updated, but is still present
+    latest=true should prefer ESGF replies when they have the latest flag
+    """
+    with mock.patch('arccssive2.esgf.esgf_query', side_effect=updated_query):
+        results = find_local_path(session, '', latest=True)
+        assert results.count() == 0

--- a/test/test_esgf.py
+++ b/test/test_esgf.py
@@ -63,6 +63,27 @@ def present_query(*args, **kwags):
                 'docs': [{
                     'id': 'abcde',
                     'checksum': ['3ea60eacd2a6e98b13fc3b242f585fdc'],
+                    'title': 'va_6hrPlev_FGOALS-g2_historical_r3i1p1_1999010106-2000010100.nc',
+                    'version': '1',
+                    'score': 1.0,
+                    }],
+                }
+            }
+    return response
+
+def updated_query(*args, **kwags):
+    """
+    A query returning something that is in the DB, but has been updated on ESGF
+    """
+    response =  {
+            'responseHeader': {'params': {'rows': 1}},
+            'response': {
+                'numFound': 1,
+                'docs': [{
+                    'id': 'abcde',
+                    'checksum': ['1234'],
+                    'version': '2',
+                    'title': 'va_6hrPlev_FGOALS-g2_historical_r3i1p1_1999010106-2000010100.nc',
                     'score': 1.0,
                     }],
                 }
@@ -119,3 +140,19 @@ def test_find_missing_id_present(session):
     with mock.patch('arccssive2.esgf.esgf_query', side_effect=present_query):
         results = find_missing_id(session, '')
         assert results.count() == 0
+
+def test_find_missing_id_updated(session):
+    """
+    File has been updated, but is still present
+    """
+    with mock.patch('arccssive2.esgf.esgf_query', side_effect=updated_query):
+        results = find_missing_id(session, '')
+        assert results.count() == 0
+
+def test_find_local_path_updated(session):
+    """
+    File has been updated, but is still present
+    """
+    with mock.patch('arccssive2.esgf.esgf_query', side_effect=updated_query):
+        results = find_local_path(session, '')
+        assert results.count() == 1


### PR DESCRIPTION
Files that `esgf local` doesn't find are now found by `esgf missing`, as they are using the same backend for their queries.

`esgf local` searches now always go through the ESGF web search. This may result in some local files not being found if an ESGF node is down, or if the data has been unpublished from ESGF.

Also add some better testing.

Fixes #9 and #7